### PR TITLE
Pin GitHub Actions to specific SHAs (2 actions in 1 files)

### DIFF
--- a/.github/workflows/ci_app.yml
+++ b/.github/workflows/ci_app.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e  # actions/checkout@v1
       with:
         lfs: false
     - name: Trailing whitespace check
-      uses: optroodt/github-action-whitespace-linter@master
+      uses: optroodt/github-action-whitespace-linter@46e46d2d4175dcc96729ced4e3a752764473740b  # optroodt/github-action-whitespace-linter@master
       with:
         files: "./vscode-dbt/*"


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 1
- **Actions pinned**: 2

### 📝 Changes by file

#### `.github/workflows/ci_app.yml`

- 📌 `actions/checkout@v1` → `actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e  # actions/checkout@v1`
- 📌 `optroodt/github-action-whitespace-linter@master` → `optroodt/github-action-whitespace-linter@46e46d2d4175dcc96729ced4e3a752764473740b  # optroodt/github-action-whitespace-linter@master`

